### PR TITLE
Updated docs to refer to `stable`, not `master`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: false
 # Only fire off builds for specific branches.
 branches:
   only:
-    - master
+    - develop
+    - stable
 env:
   global:
   - LC_CTYPE=en_US.UTF-8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Initial release.
 
 ## x.x.x
 
-This is a template. When cutting a new release, rename "master" to the release number and create a
+This is a template. When cutting a new release, rename "stable" to the release number and create a
 new, empty "Master" section.
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 MDFTextAccessibility assists in selecting text colors that will meet the
 [W3C standards for accessibility](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
 
-[![Build Status](https://travis-ci.org/material-foundation/material-text-accessibility-ios.svg?branch=master)](https://travis-ci.org/material-foundation/material-text-accessibility-ios)
-[![Code Coverage](http://codecov.io/github/material-foundation/material-text-accessibility-ios/coverage.svg?branch=master)](http://codecov.io/github/material-foundation/material-text-accessibility-ios?branch=master)
+[![Build Status](https://travis-ci.org/material-foundation/material-text-accessibility-ios.svg?branch=develop)](https://travis-ci.org/material-foundation/material-text-accessibility-ios)
+[![Code Coverage](http://codecov.io/github/material-foundation/material-text-accessibility-ios/coverage.svg?branch=develop)](http://codecov.io/github/material-foundation/material-text-accessibility-ios?branch=develop)
 
 *May 24, 2016: We're still staging MDFTextAccessibility, feel free to poke
 around, but non-code things like CocoaPods support and continuous integration


### PR DESCRIPTION
Closes #9 