### PR TITLE
Update bazel workspace to latest versions.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -21,6 +21,7 @@ set -e
 set -x
 
 KOKORO_RUNNER_VERSION="v3.*"
+BAZEL_VERSION="0.20.0"
 
 fix_bazel_imports() {
   if [ -z "$KOKORO_BUILD_NUMBER" ]; then
@@ -57,7 +58,7 @@ fix_bazel_imports
 
 if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
-  use_bazel.sh 0.20.0
+  use_bazel.sh "$BAZEL_VERSION"
   bazel version
 fi
 

--- a/.kokoro
+++ b/.kokoro
@@ -55,6 +55,12 @@ popd
 
 fix_bazel_imports
 
+if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+  bazel version
+  use_bazel.sh 0.20.0
+  bazel version
+fi
+
 ./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
 
 echo "Success!"

--- a/.kokoro
+++ b/.kokoro
@@ -62,6 +62,6 @@ if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
 fi
 
-./.kokoro-ios-runner/bazel.sh test //:UnitTests 8.1.0
+./.kokoro-ios-runner/bazel.sh test //:UnitTests 9.0.0
 
 echo "Success!"

--- a/BUILD
+++ b/BUILD
@@ -43,6 +43,7 @@ swift_library(
     resources = glob(["tests/resources/*"]),
     deps = [":MDFTextAccessibility"],
     visibility = ["//visibility:private"],
+    copts = ["-swift-version", "3"],
 )
 
 ios_unit_test(
@@ -50,6 +51,7 @@ ios_unit_test(
     deps = [
       ":UnitTestsSwiftLib"
     ],
+    minimum_os_version = "8.2",
     timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/BUILD
+++ b/BUILD
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
-load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@bazel_ios_warnings//:strict_warnings_objc_library.bzl", "strict_warnings_objc_library")
 
 licenses(["notice"])  # Apache 2.0
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,14 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "7ea0557",
+    tag = "0.9.0",
 )
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    tag = "0.4.0",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
 
 git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
-    tag = "v1.0.1",
+    tag = "v2.0.0",
+)
+
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
 )


### PR DESCRIPTION
This increases the following versions:

- bazel from 0.11 to 0.20.0
- build_bazel_rules_apple from 7ea0557 to 0.9.0
- build_bazel_rules_swift to 0.4.0 (new)
- bazel_ios_warnings from v1.0.1 to v2.0.0
- swift to 3
- minimum_os_version to 8.2 due to unguarded use of 8.2 APIs in unit tests.
- Xcode 8 to 9

Tested by running:

    bazel test //...