### PR TITLE
{bazel} Update to latest releases

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,6 +22,7 @@ exports_files(["LICENSE"])
 
 strict_warnings_objc_library(
     name = "MDFTextAccessibility",
+    module_name = "MDFTextAccessibility",
     srcs = glob([
         "src/*.m",
         "src/private/*.m",
@@ -40,7 +41,7 @@ swift_library(
     srcs = glob([
         "tests/unit/*.swift",
     ]),
-    resources = glob(["tests/resources/*"]),
+    data = glob(["tests/resources/*"]),
     deps = [":MDFTextAccessibility"],
     visibility = ["//visibility:private"],
     copts = ["-swift-version", "3"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.9.0",
+    tag = "0.13.0",
 )
 
 load(
@@ -31,7 +31,7 @@ apple_rules_dependencies()
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.4.0",
+    tag = "0.6.0",
 )
 
 load(


### PR DESCRIPTION
* Updates `bazel_rules_swift` to 0.6.0 (from 0.4.0)
* Updates `bazel_rules_apple` to 0.13.0 (from 0.9.0)
* Migrates `resources` attributes to `data`

Tested with bazel 0.22.0