### PR TITLE
Update minimum iOS version to 9.0.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -20,7 +20,7 @@ set -e
 # Display commands to stderr.
 set -x
 
-KOKORO_RUNNER_VERSION="v3.*"
+KOKORO_RUNNER_VERSION="v4.*"
 BAZEL_VERSION="0.20.0"
 
 fix_bazel_imports() {
@@ -29,19 +29,6 @@ fix_bazel_imports() {
   else
     tests_dir_prefix="github/repo/"
   fi
-  
-  rewrite_source() {
-    find "${stashed_dir}${tests_dir_prefix}tests/unit" -type f -name '*.swift' -exec sed -i '' -E "$1" {} + || true
-  }
-
-  stashed_dir=""
-  rewrite_source "s/import MDFTextAccessibility/import _MDFTextAccessibility/"
-  stashed_dir="$(pwd)/"
-  reset_imports() {
-    # Undoes our source changes from above.
-    rewrite_source "s/import _MDFTextAccessibility/import MDFTextAccessibility/"
-  }
-  trap reset_imports EXIT
 }
 
 if [ ! -d .kokoro-ios-runner ]; then
@@ -62,6 +49,6 @@ if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   bazel version
 fi
 
-./.kokoro-ios-runner/bazel.sh test //:UnitTests 9.0.0
+./.kokoro-ios-runner/bazel.sh test //:UnitTests --min-xcode-version 9.0.0
 
 echo "Success!"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode9
 sudo: false
 # Only fire off builds for specific branches.
 branches:

--- a/BUILD
+++ b/BUILD
@@ -22,6 +22,7 @@ exports_files(["LICENSE"])
 
 strict_warnings_objc_library(
     name = "MDFTextAccessibility",
+    module_name = "MDFTextAccessibility",
     srcs = glob([
         "src/*.m",
         "src/private/*.m",
@@ -43,7 +44,7 @@ swift_library(
     resources = glob(["tests/resources/*"]),
     deps = [":MDFTextAccessibility"],
     visibility = ["//visibility:private"],
-    copts = ["-swift-version", "3"],
+    copts = ["-swift-version", "4"],
 )
 
 ios_unit_test(

--- a/BUILD
+++ b/BUILD
@@ -51,7 +51,7 @@ ios_unit_test(
     deps = [
       ":UnitTestsSwiftLib"
     ],
-    minimum_os_version = "8.2",
+    minimum_os_version = "9.0",
     timeout = "short",
     visibility = ["//visibility:private"],
 )

--- a/MDFTextAccessibility.podspec
+++ b/MDFTextAccessibility.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |spec|
   spec.public_header_files = "src/MDFTextAccessibility.h"
   spec.private_header_files = "src/private/*.h"
   spec.header_dir   = "MDFTextAccessibility"
-  spec.ios.deployment_target = '8.0'
+  spec.ios.deployment_target = '9.0'
   spec.tvos.deployment_target = '9.0'
 end

--- a/MDFTextAccessibility.xcodeproj/project.pbxproj
+++ b/MDFTextAccessibility.xcodeproj/project.pbxproj
@@ -221,16 +221,15 @@
 					};
 					0BDAE3DF1CECD3A6003323B9 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1120;
 					};
 				};
 			};
 			buildConfigurationList = 0B2890D61CE27291009E605A /* Build configuration list for PBXProject "MDFTextAccessibility" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 			);
 			mainGroup = 0B2890D21CE27291009E605A;
@@ -364,7 +363,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "tests/unit/MDFTextAccessibility-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -413,7 +412,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "tests/unit/MDFTextAccessibility-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -470,7 +469,7 @@
 				SWIFT_INCLUDE_PATHS = src;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/MDFTextAccessibility-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -518,7 +517,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = src;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/MDFTextAccessibility-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/MDFTextAccessibility.xcodeproj/project.pbxproj
+++ b/MDFTextAccessibility.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 0B2890D21CE27291009E605A;
@@ -293,7 +294,7 @@
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				WARNING_CFLAGS = "-Wall";
 			};
@@ -304,7 +305,7 @@
 			baseConfigurationReference = 0B96D67A1D5CD06100491BDC /* MDFTextAccessibility.xcconfig */;
 			buildSettings = {
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				WARNING_CFLAGS = "-Wall";
 			};
 			name = Release;
@@ -349,7 +350,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = src/module.modulemap;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -400,7 +401,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = src/module.modulemap;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/MDFTextAccessibility.xcodeproj/project.pbxproj
+++ b/MDFTextAccessibility.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "tests/unit/MDFTextAccessibility-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -412,7 +412,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "tests/unit/MDFTextAccessibility-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -456,7 +456,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = tests/unit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks /usr/lib/swift";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -469,7 +469,7 @@
 				SWIFT_INCLUDE_PATHS = src;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/MDFTextAccessibility-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -506,7 +506,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = tests/unit/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks /usr/lib/swift";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -517,7 +517,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = src;
 				SWIFT_OBJC_BRIDGING_HEADER = "src/MDFTextAccessibility-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ For more advanced usage, such as selecting from a set of colors other than white
 and black, see MDFTextAccessibility's
 `textColorFromChoices:onBackgroundColor:options:`.
 
+## Requirements
+
+- Xcode 9 or higher
+- Minimum iOS deployment target of 9.0 or higher
+- CocoaPods 1.5 or higher
+
 ## License
 
 MDFTextAccessiblity is licensed under the [Apache License Version 2.0](LICENSE).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,11 +44,11 @@ swift_rules_dependencies()
 git_repository(
     name = "bazel_ios_warnings",
     remote = "https://github.com/material-foundation/bazel_ios_warnings.git",
-    tag = "v2.0.0",
+    tag = "v3.0.0",
 )
 
 http_file(
     name = "xctestrunner",
     executable = 1,
-    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.5/ios_test_runner.par"],
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.10/ios_test_runner.par"],
 )

--- a/tests/unit/MDFTextAccessibilityUnitTests.swift
+++ b/tests/unit/MDFTextAccessibilityUnitTests.swift
@@ -83,7 +83,7 @@ class MDFTextAccessibilityUnitTests: XCTestCase {
     let minAlpha = MDFTextAccessibility.minAlpha(ofTextColor: textColor,
         onBackgroundColor:backgroundColor,
         options:MDFTextAccessibilityOptions())
-    XCTAssertEqualWithAccuracy(minAlpha, 0.54, accuracy: alphaEpsilon)
+    XCTAssertEqual(minAlpha, 0.54, accuracy: alphaEpsilon)
   }
 
   func testLargeTextBlackOnWhiteMinAlpha() {
@@ -92,7 +92,7 @@ class MDFTextAccessibilityUnitTests: XCTestCase {
     let minAlpha = MDFTextAccessibility.minAlpha(ofTextColor: textColor,
         onBackgroundColor:backgroundColor,
         options:MDFTextAccessibilityOptions.largeFont)
-    XCTAssertEqualWithAccuracy(minAlpha, 0.42, accuracy: alphaEpsilon)
+    XCTAssertEqual(minAlpha, 0.42, accuracy: alphaEpsilon)
   }
 
   func testMinAlphaIgnoresColorAlpha() {
@@ -107,7 +107,7 @@ class MDFTextAccessibilityUnitTests: XCTestCase {
         onBackgroundColor:backgroundColor,
         options:MDFTextAccessibilityOptions())
 
-    XCTAssertEqualWithAccuracy(minAlpha, minAlphaWithColorWithAlpha, accuracy: alphaEpsilon)
+    XCTAssertEqual(minAlpha, minAlphaWithColorWithAlpha, accuracy: alphaEpsilon)
   }
 
   // MARK: Accessibility standard tests
@@ -225,17 +225,17 @@ class MDFTextAccessibilityUnitTests: XCTestCase {
     XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 10)))
 
     // Bold and thicker fonts are considered large at a lower font size than nonbold fonts.
-    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightBlack)))
-    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightHeavy)))
-    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightBold)))
+    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .black)))
+    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .heavy)))
+    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .bold)))
     // Semibold is considered bold by iOS font-weight APIs: fontDescriptor.symbolicTraits & UIFontDescriptorTraitBold.
-    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightSemibold)))
+    XCTAssertTrue(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .semibold)))
 
     // Non-bold fonts are not considered large at the lower font size threshold.
-    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightMedium)))
-    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightRegular)))
-    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightLight)))
-    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightThin)))
-    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: UIFontWeightUltraLight)))
+    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .medium)))
+    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .regular)))
+    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .light)))
+    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .thin)))
+    XCTAssertFalse(MDFTextAccessibility.isLarge(forContrastRatios: UIFont.systemFont(ofSize: 15, weight: .ultraLight)))
   }
 }


### PR DESCRIPTION
In this PR we are updating the minimum iOS version to 9.0.

For this we needed to update:

- the travis file to have the correct xcode image
- BUILD file to the new min version and with it the min swift version requirement
- xcodeproj file to minimum ios version of 9.0
- Updates to old swift syntax to support Swift 4 (with it iOS 9).
- Documentation reflecting update.

Closes b/128407251

Tested building in Xcode and using blaze.

Follow up to this would be releasing v3.0.0 and pushing to CocoaPods.