### PR TITLE
Adding SPM Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "MDFTextAccessibility",
     platforms: [
-        .iOS("9.0"), .tvOS("9.0")
+        .iOS("8.0"), .tvOS("9.0")
     ],
     products: [
         .library(name: "MDFTextAccessibility", targets: ["MDFTextAccessibility"])

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,19 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+// Copyright 2020-present the Material Text Accessibility for iOS authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "MDFTextAccessibility",
+    platforms: [
+        .iOS("9.0"), .tvOS("9.0")
+    ],
+    products: [
+        .library(name: "MDFTextAccessibility", targets: ["MDFTextAccessibility"])
+    ],
+    targets: [
+        .target(
+            name: "MDFTextAccessibility",
+            path: "src",
+            publicHeadersPath: ".")
+    ]
+)

--- a/src/module.modulemap
+++ b/src/module.modulemap
@@ -1,5 +1,0 @@
-module MDFTextAccessibility {
-  requires objc, objc_arc
-  header "MDFTextAccessibility.h"
-  header "MDFTextAccessibility-Bridging-Header.h"
-}


### PR DESCRIPTION
- Added SPM support. Once added to a project, the package can be imported the same way as you would with Cocoapods (`import MDFTextAccessibility`)
- There are no changes to the file structure or Cocoapods related files.